### PR TITLE
Fix/crashes on safari

### DIFF
--- a/src/targets/web/index.js
+++ b/src/targets/web/index.js
@@ -36,7 +36,7 @@ export function useReduceMotion() {
       if (usesDepreciatedApi) {
         mq.removeListener(handleChange);
       } else {
-        mq.addEventListener('change', handleChange);
+        mq.removeEventListener('change', handleChange);
       }
     };
   }, []);

--- a/src/targets/web/index.js
+++ b/src/targets/web/index.js
@@ -24,21 +24,21 @@ export function useReduceMotion() {
     };
     handleChange();
     // If only has depreciated api use that, otherwise use current api
-		// Safari 14 + has both, Safari <= 13 only has depreciated
-		// fixes https://github.com/infiniteluke/react-reduce-motion/issues/8
+    // Safari 14 + has both, Safari <= 13 only has depreciated
+    // fixes https://github.com/infiniteluke/react-reduce-motion/issues/8
     const usesDepreciatedApi = mq.addListener && !mq.addEventListener;
-		if (usesDepreciatedApi) {
-			mq.addListener(handleChange);
-		} else {
-			mq.addEventListener('change', handleChange);
-		}
-		return () => {
-			if (usesDepreciatedApi) {
-				mq.removeListener(handleChange);
-			} else {
-				mq.addEventListener('change', handleChange);
-			}
-		};
-	}, []);
+    if (usesDepreciatedApi) {
+      mq.addListener(handleChange);
+    } else {
+      mq.addEventListener('change', handleChange);
+    }
+    return () => {
+      if (usesDepreciatedApi) {
+        mq.removeListener(handleChange);
+      } else {
+        mq.addEventListener('change', handleChange);
+      }
+    };
+  }, []);
   return matches;
 }

--- a/src/targets/web/index.js
+++ b/src/targets/web/index.js
@@ -23,17 +23,17 @@ export function useReduceMotion() {
       setMatch(mq.matches);
     };
     handleChange();
-    // If only has depreciated api use that, otherwise use current api
-    // Safari 14 + has both, Safari <= 13 only has depreciated
+    // If only has deprecated api use that, otherwise use current api
+    // Safari 14 + has both, Safari <= 13 only has deprecated
     // fixes https://github.com/infiniteluke/react-reduce-motion/issues/8
-    const usesDepreciatedApi = mq.addListener && !mq.addEventListener;
-    if (usesDepreciatedApi) {
+    const usesDeprecatedApi = mq.addListener && !mq.addEventListener;
+    if (usesDeprecatedApi) {
       mq.addListener(handleChange);
     } else {
       mq.addEventListener('change', handleChange);
     }
     return () => {
-      if (usesDepreciatedApi) {
+      if (usesDeprecatedApi) {
         mq.removeListener(handleChange);
       } else {
         mq.removeEventListener('change', handleChange);

--- a/src/targets/web/index.js
+++ b/src/targets/web/index.js
@@ -23,10 +23,22 @@ export function useReduceMotion() {
       setMatch(mq.matches);
     };
     handleChange();
-    mq.addEventListener('change', handleChange);
-    return () => {
-      mq.removeEventListener('change', handleChange);
-    };
-  }, []);
+    // If only has depreciated api use that, otherwise use current api
+		// Safari 14 + has both, Safari <= 13 only has depreciated
+		// fixes https://github.com/infiniteluke/react-reduce-motion/issues/8
+    const usesDepreciatedApi = mq.addListener && !mq.addEventListener;
+		if (usesDepreciatedApi) {
+			mq.addListener(handleChange);
+		} else {
+			mq.addEventListener('change', handleChange);
+		}
+		return () => {
+			if (usesDepreciatedApi) {
+				mq.removeListener(handleChange);
+			} else {
+				mq.addEventListener('change', handleChange);
+			}
+		};
+	}, []);
   return matches;
 }


### PR DESCRIPTION
This pull request fixes https://github.com/infiniteluke/react-reduce-motion/issues/8

It should no longer cause crashing in safari <= 13

Safari 14 implements both the addListener and addEventListener apis, so we only use the older addListener if the browser has addListener but not addEventListener.

Thanks!